### PR TITLE
Added prettier config file to have a consistent formatting

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": true,
+  "printWidth": 100,
+  "tabWidth": 2
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,29 +1,29 @@
-import * as React from "react";
-import Dashboard from "./pages/Dashboard";
-import ApplicantsPage from "./pages/ApplicantsPage";
-import OverviewPage from "./pages/OverviewPage";
-import UploadPage from "./pages/UploadPage";
-import InquiriesPage from "./pages/InquiriesPage";
-import PositionPage from "./pages/PositionPage";
-import SettingsPage from "./pages/SettingsPage";
-import { BrowserRouter, Route, Routes } from "react-router-dom";
-import Box from "@mui/material/Box";
-import AppBar from "./components/AppBar";
-import Drawer from "./components/Drawer";
-import { styled } from "@mui/material";
+import * as React from 'react';
+import Dashboard from './pages/Dashboard';
+import ApplicantsPage from './pages/ApplicantsPage';
+import OverviewPage from './pages/OverviewPage';
+import UploadPage from './pages/UploadPage';
+import InquiriesPage from './pages/InquiriesPage';
+import PositionPage from './pages/PositionPage';
+import SettingsPage from './pages/SettingsPage';
+import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import Box from '@mui/material/Box';
+import AppBar from './components/AppBar';
+import Drawer from './components/Drawer';
+import { styled } from '@mui/material';
 
 export default function App() {
   const MainBox = styled(Box)(({ theme }) => ({
     flexGrow: 1,
-    height: "100dvh",
-    overflow: "auto",
+    height: '100dvh',
+    overflow: 'auto',
     background: theme.palette.background.default,
-    boxShadow: "none",
+    boxShadow: 'none',
     marginLeft: theme.spacing(28),
   }));
   return (
     <BrowserRouter>
-      <Box sx={{ display: "flex" }}>
+      <Box sx={{ display: 'flex' }}>
         <AppBar />
         <Drawer />
         <MainBox component="main">

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -1,58 +1,58 @@
-import * as React from "react";
-import { styled } from "@mui/material/styles";
-import MuiAppBar, { AppBarProps as MuiAppBarProps } from "@mui/material/AppBar";
-import Toolbar from "@mui/material/Toolbar";
-import Badge from "@mui/material/Badge";
-import NotificationsIcon from "@mui/icons-material/Notifications";
-import SearchIcon from "@mui/icons-material/Search";
-import InputBase from "@mui/material/InputBase";
-import Avatar from "@mui/material/Avatar";
-import Box from "@mui/material/Box";
-import Typography from "@mui/material/Typography";
-import AccountTreeOutlinedIcon from "@mui/icons-material/AccountTreeOutlined";
+import * as React from 'react';
+import { styled } from '@mui/material/styles';
+import MuiAppBar, { AppBarProps as MuiAppBarProps } from '@mui/material/AppBar';
+import Toolbar from '@mui/material/Toolbar';
+import Badge from '@mui/material/Badge';
+import NotificationsIcon from '@mui/icons-material/Notifications';
+import SearchIcon from '@mui/icons-material/Search';
+import InputBase from '@mui/material/InputBase';
+import Avatar from '@mui/material/Avatar';
+import Box from '@mui/material/Box';
+import Typography from '@mui/material/Typography';
+import AccountTreeOutlinedIcon from '@mui/icons-material/AccountTreeOutlined';
 
 export default function AppBar() {
   const AppBarMod = styled(MuiAppBar)(({ theme }) => ({
     background: theme.palette.grey[100],
-    boxShadow: "none",
+    boxShadow: 'none',
     zIndex: theme.zIndex.drawer + 1,
-    position: "absolute",
+    position: 'absolute',
   }));
 
-  const Search = styled("div")(({ theme }) => ({
-    position: "relative",
+  const Search = styled('div')(({ theme }) => ({
+    position: 'relative',
     borderRadius: theme.shape.borderRadius,
     backgroundColor: theme.palette.grey[100],
-    "&:hover": {
+    '&:hover': {
       backgroundColor: theme.palette.grey[100],
     },
-    width: "50%",
+    width: '50%',
   }));
 
-  const SearchIconWrapper = styled("div")(({ theme }) => ({
+  const SearchIconWrapper = styled('div')(({ theme }) => ({
     padding: theme.spacing(0, 2),
-    color: "black",
-    height: "100%",
-    position: "absolute",
-    pointerEvents: "none",
-    display: "flex",
-    alignItems: "center",
-    justifyContent: "center",
+    color: 'black',
+    height: '100%',
+    position: 'absolute',
+    pointerEvents: 'none',
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
   }));
 
   const StyledInputBase = styled(InputBase)(({ theme }) => ({
-    color: "inherit",
-    "& .MuiInputBase-input": {
+    color: 'inherit',
+    '& .MuiInputBase-input': {
       padding: theme.spacing(1, 1, 1, 0),
       // vertical padding + font size from searchIcon
       paddingLeft: `calc(1em + ${theme.spacing(4)})`,
-      transition: theme.transitions.create("width"),
-      width: "100%",
-      color: "black",
-      [theme.breakpoints.up("sm")]: {
-        width: "12ch",
-        "&:focus": {
-          width: "20ch",
+      transition: theme.transitions.create('width'),
+      width: '100%',
+      color: 'black',
+      [theme.breakpoints.up('sm')]: {
+        width: '12ch',
+        '&:focus': {
+          width: '20ch',
         },
       },
     },
@@ -63,22 +63,22 @@ export default function AppBar() {
       <Toolbar
         sx={{
           ml: 2,
-          display: "flex",
-          alignItems: "center",
-          justifyContent: "space-between",
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
         }}
       >
         <Box
           sx={{
             flexGrow: 0,
-            display: "flex",
-            alignItems: "flex-start",
+            display: 'flex',
+            alignItems: 'flex-start',
             ml: -2,
           }}
         >
           <AccountTreeOutlinedIcon
             sx={{
-              display: { xs: "none", md: "flex" },
+              display: { xs: 'none', md: 'flex' },
               mr: 2,
             }}
             color="secondary"
@@ -90,8 +90,8 @@ export default function AppBar() {
             noWrap
             sx={{
               mr: 2,
-              display: { xs: "none", md: "flex" },
-              fontFamily: "",
+              display: { xs: 'none', md: 'flex' },
+              fontFamily: '',
               fontWeight: 400,
             }}
           >
@@ -110,13 +110,13 @@ export default function AppBar() {
         <Box
           sx={{
             flexGrow: 0,
-            display: "flex",
-            alignItems: "center",
-            justifyContent: "right",
+            display: 'flex',
+            alignItems: 'center',
+            justifyContent: 'right',
           }}
         >
-          <Avatar alt="user" src={"a"} sx={{ p: 0, mr: 2, ml: 2 }} />
-          <Typography sx={{ mr: 2, color: "black" }}>Manuel Neuer</Typography>
+          <Avatar alt="user" src={'a'} sx={{ p: 0, mr: 2, ml: 2 }} />
+          <Typography sx={{ mr: 2, color: 'black' }}>Manuel Neuer</Typography>
           <Badge badgeContent={4} color="secondary" sx={{ ml: 2 }}>
             <NotificationsIcon color="primary" />
           </Badge>

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -1,12 +1,12 @@
-import * as React from "react";
-import { styled } from "@mui/material/styles";
-import MuiDrawer from "@mui/material/Drawer";
-import DrawerItems from "../helper/DrawerItems";
+import * as React from 'react';
+import { styled } from '@mui/material/styles';
+import MuiDrawer from '@mui/material/Drawer';
+import DrawerItems from '../helper/DrawerItems';
 
 export default function Drawer() {
   const DrawerMod = styled(MuiDrawer)(({ theme }) => ({
-    "& .MuiDrawer-paper": {
-      position: "fixed",
+    '& .MuiDrawer-paper': {
+      position: 'fixed',
       background: theme.palette.grey[100],
       width: theme.spacing(28),
       marginTop: theme.spacing(8),

--- a/src/helper/DrawerItems.tsx
+++ b/src/helper/DrawerItems.tsx
@@ -1,24 +1,24 @@
-import * as React from "react";
-import ListItemButton from "@mui/material/ListItemButton";
-import ListItemIcon from "@mui/material/ListItemIcon";
-import ListItemText from "@mui/material/ListItemText";
-import DashboardIcon from "@mui/icons-material/Dashboard";
-import PeopleIcon from "@mui/icons-material/People";
-import BarChartIcon from "@mui/icons-material/BarChart";
-import LayersIcon from "@mui/icons-material/Layers";
-import AssignmentIcon from "@mui/icons-material/Assignment";
-import Divider from "@mui/material/Divider";
-import { NavLink } from "react-router-dom";
-import Collapse from "@mui/material/Collapse";
-import List from "@mui/material/List";
-import ExpandLess from "@mui/icons-material/ExpandLess";
-import ExpandMore from "@mui/icons-material/ExpandMore";
-import FileUploadIcon from "@mui/icons-material/FileUpload";
-import GridViewIcon from "@mui/icons-material/GridView";
+import * as React from 'react';
+import ListItemButton from '@mui/material/ListItemButton';
+import ListItemIcon from '@mui/material/ListItemIcon';
+import ListItemText from '@mui/material/ListItemText';
+import DashboardIcon from '@mui/icons-material/Dashboard';
+import PeopleIcon from '@mui/icons-material/People';
+import BarChartIcon from '@mui/icons-material/BarChart';
+import LayersIcon from '@mui/icons-material/Layers';
+import AssignmentIcon from '@mui/icons-material/Assignment';
+import Divider from '@mui/material/Divider';
+import { NavLink } from 'react-router-dom';
+import Collapse from '@mui/material/Collapse';
+import List from '@mui/material/List';
+import ExpandLess from '@mui/icons-material/ExpandLess';
+import ExpandMore from '@mui/icons-material/ExpandMore';
+import FileUploadIcon from '@mui/icons-material/FileUpload';
+import GridViewIcon from '@mui/icons-material/GridView';
 
 const linkStyle = {
-  textDecoration: "none",
-  color: "black",
+  textDecoration: 'none',
+  color: 'black',
 };
 
 export default function DrawerItems() {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,11 +1,11 @@
-import * as React from "react";
-import * as ReactDOM from "react-dom/client";
-import CssBaseline from "@mui/material/CssBaseline";
-import { ThemeProvider } from "@mui/material/styles";
-import App from "./App";
-import theme from "./theme";
+import * as React from 'react';
+import * as ReactDOM from 'react-dom/client';
+import CssBaseline from '@mui/material/CssBaseline';
+import { ThemeProvider } from '@mui/material/styles';
+import App from './App';
+import theme from './theme';
 
-const rootElement = document.getElementById("root");
+const rootElement = document.getElementById('root');
 const root = ReactDOM.createRoot(rootElement!);
 
 root.render(

--- a/src/theme.ts
+++ b/src/theme.ts
@@ -1,20 +1,20 @@
-import { createTheme } from "@mui/material/styles";
-import { red } from "@mui/material/colors";
+import { createTheme } from '@mui/material/styles';
+import { red } from '@mui/material/colors';
 
 // A custom theme for this app
 const theme = createTheme({
   palette: {
     background: {
-      default: "#ffffff",
+      default: '#ffffff',
     },
     grey: {
-      100: "#edf0f5",
+      100: '#edf0f5',
     },
     primary: {
-      main: "#1a1a1a",
+      main: '#1a1a1a',
     },
     secondary: {
-      main: "#80b038",
+      main: '#80b038',
     },
     error: {
       main: red.A400,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -20,7 +16,5 @@
     "noEmit": true,
     "jsx": "react-jsx"
   },
-  "include": [
-    "src"
-  ]
+  "include": ["src"]
 }


### PR DESCRIPTION
Chosen configuration:
- `'semi': true` - print semicolons at the ends of statements
- `"trailingComma": "es5"` -  print trailing commas where valid in ES5 (objects, arrays, etc.)
- `"singleQuote": true` - use single quotes instead of double quotes
- `"printWidth": 100` - specifies the line length that the printer will wrap on (80 is recommended, but since we are using TypeScript, a line width of 80 impacted readability negatively in a previous project)
- `"tabWidth": 2` - specifies the number of spaces per indentation-level

For further information or requesting some more options check the [docs](https://prettier.io/docs/en/options).