### PR TITLE
Adjust drawer to match mockup

### DIFF
--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -80,12 +80,13 @@ export default function AppBar() {
             sx={{
               display: { md: 'flex' },
               mr: 2,
+              mt: 1,
               '&:hover': {
                 cursor: 'pointer',
               },
+              fontSize: 60,
             }}
             color="secondary"
-            fontSize="large"
             fontWeight="bold"
             onClick={() => {
               navigate('/');
@@ -93,11 +94,12 @@ export default function AppBar() {
           />
           <Typography
             component="h1"
-            variant="h4"
+            variant="h3"
             color="secondary"
             noWrap
             sx={{
               mr: 2,
+              mt: 2,
               display: { md: 'flex' },
               fontFamily: 'Lato',
               fontWeight: 'bold',

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -11,6 +11,7 @@ import Box from '@mui/material/Box';
 import Typography from '@mui/material/Typography';
 import CallMergeIcon from '@mui/icons-material/CallMerge';
 import { useNavigate } from 'react-router-dom';
+import { FONT_FAMILY } from '../constants';
 
 export default function AppBar() {
   const navigate = useNavigate();
@@ -20,6 +21,7 @@ export default function AppBar() {
     boxShadow: 'none',
     position: 'fixed',
     height: theme.spacing(8),
+    zIndex: theme.zIndex.drawer + 1,
   }));
 
   const Search = styled('div')(({ theme }) => ({
@@ -101,7 +103,7 @@ export default function AppBar() {
               mr: 2,
               mt: 2,
               display: { md: 'flex' },
-              fontFamily: 'Lato',
+              fontFamily: FONT_FAMILY,
               fontWeight: 'bold',
               '&:hover': {
                 cursor: 'pointer',

--- a/src/components/AppBar.tsx
+++ b/src/components/AppBar.tsx
@@ -90,9 +90,10 @@ export default function AppBar() {
             }}
             color="secondary"
             fontWeight="bold"
-            onClick={() => {
-              navigate('/');
-            }}
+            //FIXME: If you click on either the icon or the text, the drawer does not highlight "Dashboard" as selected. Removing this could be easier, than trying to make it work.
+            //onClick={() => {
+            //  navigate('/');
+            //}}
           />
           <Typography
             component="h1"
@@ -109,9 +110,9 @@ export default function AppBar() {
                 cursor: 'pointer',
               },
             }}
-            onClick={() => {
-              navigate('/');
-            }}
+            //onClick={() => {
+            //  navigate('/');
+            //}}
           >
             SkillSync
           </Typography>

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,4 +1,4 @@
-export const DRAWER_WIDTH = 35; // -> 35px*8px = 280px
+export const DRAWER_WIDTH = 50; // -> 35px*8px = 280px
 export const APP_BAR_HEIGHT = 8; // -> 8px*8px = 64px
 export const FONT_FAMILY = 'Roboto, sans-serif';
 

--- a/src/helper/DrawerItems.tsx
+++ b/src/helper/DrawerItems.tsx
@@ -10,7 +10,6 @@ import Collapse from '@mui/material/Collapse';
 import List from '@mui/material/List';
 import ExpandLess from '@mui/icons-material/ExpandLess';
 import ExpandMore from '@mui/icons-material/ExpandMore';
-import FileUploadRoundedIcon from '@mui/icons-material/FileUploadRounded';
 import PersonAddRoundedIcon from '@mui/icons-material/PersonAddRounded';
 import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
 import { NavLink } from 'react-router-dom';
@@ -23,7 +22,7 @@ const linkStyle = {
 
 export default function DrawerItems() {
   const [open, setOpen] = useState(true);
-  const [selectedLink, setSelectedLink] = useState<string>('');
+  const [selectedLink, setSelectedLink] = useState<string>('/');
 
   const handleClick = () => {
     setOpen(!open);

--- a/src/helper/DrawerItems.tsx
+++ b/src/helper/DrawerItems.tsx
@@ -3,7 +3,7 @@ import { ListItemButton, ListItemIcon, ListItemText, Box } from '@mui/material';
 import DashboardRoundedIcon from '@mui/icons-material/DashboardRounded';
 import GroupsRoundedIcon from '@mui/icons-material/GroupsRounded';
 import MoveToInboxRoundedIcon from '@mui/icons-material/MoveToInboxRounded';
-import ViewListRoundedIcon from '@mui/icons-material/ViewListRounded';
+import BadgeRoundedIcon from '@mui/icons-material/BadgeRounded';
 import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
 import Divider from '@mui/material/Divider';
 import Collapse from '@mui/material/Collapse';
@@ -18,25 +18,24 @@ import { useState } from 'react';
 
 const linkStyle = {
   textDecoration: 'none',
-  color: '#4d4d4d',
 };
 
 export default function DrawerItems() {
   const [open, setOpen] = useState(true);
-  const [selectedLink, setSelectedLink] = useState<string>(''); // State to track selected link
+  const [selectedLink, setSelectedLink] = useState<string>('');
 
   const handleClick = () => {
     setOpen(!open);
   };
 
   const handleLinkClick = (link: string) => {
-    setSelectedLink(link); // Update selected link on click
+    setSelectedLink(link);
   };
 
   return (
     <React.Fragment>
-      <Box sx={{ marginTop: '5vh', marginLeft: '1vh', marginRight: '1vh' }}>
-        <Box sx={{ marginBottom: '3vh', borderRadius: 5 }}>
+      <Box sx={{ marginTop: '6vh', marginLeft: '2vh', marginRight: '1vh' }}>
+        <Box sx={{ marginBottom: '3vh', justifyContent: 'center', alignItems: 'center' }}>
           <NavLink to="/" style={linkStyle} onClick={() => handleLinkClick('/')}>
             <ListItemButton
               sx={{
@@ -45,12 +44,24 @@ export default function DrawerItems() {
                   backgroundColor: '#edf5e1',
                   cursor: 'pointer',
                 },
+                borderRadius: 2,
               }}
             >
               <ListItemIcon>
-                <DashboardRoundedIcon sx={{ fontSize: 30 }} />
+                <DashboardRoundedIcon
+                  sx={{ fontSize: 30, color: selectedLink === '/' ? '#4C4C4C' : '#808080' }}
+                />
               </ListItemIcon>
-              <ListItemText primary="Dashboard" primaryTypographyProps={{ sx: { fontSize: 25 } }} />
+              <ListItemText
+                primary="Dashboard"
+                primaryTypographyProps={{
+                  sx: {
+                    fontSize: 22,
+                    fontWeight: selectedLink === '/' ? 'bold' : 'normal',
+                    color: selectedLink === '/' ? '#4C4C4C' : '#808080',
+                  },
+                }}
+              />
             </ListItemButton>
           </NavLink>
         </Box>
@@ -58,17 +69,32 @@ export default function DrawerItems() {
           <NavLink to="/vacancies" style={linkStyle} onClick={() => handleLinkClick('/vacancies')}>
             <ListItemButton
               sx={{
-                backgroundColor: '#f5f5f5',
+                backgroundColor: selectedLink === '/vacancies' ? '#B4CD93' : '#f5f5f5',
                 '&:hover': {
                   backgroundColor: '#edf5e1',
                   cursor: 'pointer',
                 },
+                borderRadius: 2,
               }}
             >
               <ListItemIcon>
-                <ViewListRoundedIcon sx={{ fontSize: 30 }} />
+                <BadgeRoundedIcon
+                  sx={{
+                    fontSize: 30,
+                    color: selectedLink === '/vacancies' ? '#4C4C4C' : '#808080',
+                  }}
+                />
               </ListItemIcon>
-              <ListItemText primary="Vacancies" primaryTypographyProps={{ sx: { fontSize: 25 } }} />
+              <ListItemText
+                primary="Vacancies"
+                primaryTypographyProps={{
+                  sx: {
+                    fontSize: 22,
+                    fontWeight: selectedLink === '/vacancies' ? 'bold' : 'normal',
+                    color: selectedLink === '/vacancies' ? '#4C4C4C' : '#808080',
+                  },
+                }}
+              />
             </ListItemButton>
           </NavLink>
         </Box>
@@ -76,17 +102,32 @@ export default function DrawerItems() {
           <NavLink to="/inquiries" style={linkStyle} onClick={() => handleLinkClick('/inquiries')}>
             <ListItemButton
               sx={{
-                backgroundColor: '#f5f5f5',
+                backgroundColor: selectedLink === '/inquiries' ? '#B4CD93' : '#f5f5f5',
                 '&:hover': {
                   backgroundColor: '#edf5e1',
                   cursor: 'pointer',
                 },
+                borderRadius: 2,
               }}
             >
               <ListItemIcon>
-                <MoveToInboxRoundedIcon sx={{ fontSize: 30 }} />
+                <MoveToInboxRoundedIcon
+                  sx={{
+                    fontSize: 30,
+                    color: selectedLink === '/inquiries' ? '#4C4C4C' : '#808080',
+                  }}
+                />
               </ListItemIcon>
-              <ListItemText primary="Inquiries" primaryTypographyProps={{ sx: { fontSize: 25 } }} />
+              <ListItemText
+                primary="Inquiries"
+                primaryTypographyProps={{
+                  sx: {
+                    fontSize: 22,
+                    fontWeight: selectedLink === '/inquiries' ? 'bold' : 'normal',
+                    color: selectedLink === '/inquiries' ? '#4C4C4C' : '#808080',
+                  },
+                }}
+              />
             </ListItemButton>
           </NavLink>
         </Box>
@@ -98,20 +139,32 @@ export default function DrawerItems() {
           >
             <ListItemButton
               sx={{
-                backgroundColor: '#f5f5f5',
+                backgroundColor: selectedLink === '/applicants' ? '#B4CD93' : '#f5f5f5',
                 '&:hover': {
                   backgroundColor: '#edf5e1',
                   cursor: 'pointer',
                 },
+                borderRadius: 2,
               }}
               onClick={handleClick}
             >
               <ListItemIcon>
-                <PersonAddRoundedIcon sx={{ fontSize: 30 }} />
+                <PersonAddRoundedIcon
+                  sx={{
+                    fontSize: 30,
+                    color: selectedLink === '/applicants' ? '#4C4C4C' : '#808080',
+                  }}
+                />
               </ListItemIcon>
               <ListItemText
                 primary="Applicants"
-                primaryTypographyProps={{ sx: { fontSize: 25 } }}
+                primaryTypographyProps={{
+                  sx: {
+                    fontSize: 22,
+                    fontWeight: selectedLink === '/applicants' ? 'bold' : 'normal',
+                    color: selectedLink === '/applicants' ? '#4C4C4C' : '#808080',
+                  },
+                }}
               />
               {open ? <ExpandLess /> : <ExpandMore />}
             </ListItemButton>
@@ -128,19 +181,32 @@ export default function DrawerItems() {
                 <ListItemButton
                   sx={{
                     pl: 4,
-                    backgroundColor: '#f5f5f5',
+                    backgroundColor:
+                      selectedLink === '/applicants/overview' ? '#B4CD93' : '#f5f5f5',
                     '&:hover': {
                       backgroundColor: '#edf5e1',
                       cursor: 'pointer',
                     },
+                    borderRadius: 2,
                   }}
                 >
                   <ListItemIcon>
-                    <GroupsRoundedIcon sx={{ fontSize: 30 }} />
+                    <GroupsRoundedIcon
+                      sx={{
+                        fontSize: 30,
+                        color: selectedLink === '/applicants/overview' ? '#4C4C4C' : '#808080',
+                      }}
+                    />
                   </ListItemIcon>
                   <ListItemText
                     primary="Overview"
-                    primaryTypographyProps={{ sx: { fontSize: 20 } }}
+                    primaryTypographyProps={{
+                      sx: {
+                        fontSize: 20,
+                        fontWeight: selectedLink === '/applicants/overview' ? 'bold' : 'normal',
+                        color: selectedLink === '/applicants/overview' ? '#4C4C4C' : '#808080',
+                      },
+                    }}
                   />
                 </ListItemButton>
               </NavLink>
@@ -154,19 +220,31 @@ export default function DrawerItems() {
                 <ListItemButton
                   sx={{
                     pl: 4,
-                    backgroundColor: '#f5f5f5',
+                    backgroundColor: selectedLink === '/applicants/upload' ? '#B4CD93' : '#f5f5f5',
                     '&:hover': {
                       backgroundColor: '#edf5e1',
                       cursor: 'pointer',
                     },
+                    borderRadius: 2,
                   }}
                 >
                   <ListItemIcon>
-                    <FileUploadRoundedIcon sx={{ fontSize: 30 }} />
+                    <FileUploadRoundedIcon
+                      sx={{
+                        fontSize: 30,
+                        color: selectedLink === '/applicants/upload' ? '#4C4C4C' : '#808080',
+                      }}
+                    />
                   </ListItemIcon>
                   <ListItemText
                     primary="Upload"
-                    primaryTypographyProps={{ sx: { fontSize: 20 } }}
+                    primaryTypographyProps={{
+                      sx: {
+                        fontSize: 20,
+                        fontWeight: selectedLink === '/applicants/upload' ? 'bold' : 'normal',
+                        color: selectedLink === '/applicants/upload' ? '#4C4C4C' : '#808080',
+                      },
+                    }}
                   />
                 </ListItemButton>
               </NavLink>
@@ -178,17 +256,29 @@ export default function DrawerItems() {
           <NavLink to="/settings" style={linkStyle} onClick={() => handleLinkClick('/settings')}>
             <ListItemButton
               sx={{
-                backgroundColor: '#f5f5f5',
+                backgroundColor: selectedLink === '/settings' ? '#B4CD93' : '#f5f5f5',
                 '&:hover': {
                   backgroundColor: '#edf5e1',
                   cursor: 'pointer',
                 },
+                borderRadius: 2,
               }}
             >
               <ListItemIcon>
-                <SettingsRoundedIcon sx={{ fontSize: 30 }} />
+                <SettingsRoundedIcon
+                  sx={{ fontSize: 30, color: selectedLink === '/settings' ? '#4C4C4C' : '#808080' }}
+                />
               </ListItemIcon>
-              <ListItemText primary="Settings" primaryTypographyProps={{ sx: { fontSize: 25 } }} />
+              <ListItemText
+                primary="Settings"
+                primaryTypographyProps={{
+                  sx: {
+                    fontSize: 22,
+                    fontWeight: selectedLink === '/settings' ? 'bold' : 'normal',
+                    color: selectedLink === '/settings' ? '#4C4C4C' : '#808080',
+                  },
+                }}
+              />
             </ListItemButton>
           </NavLink>
         </Box>
@@ -196,17 +286,29 @@ export default function DrawerItems() {
           <NavLink to="/logout" style={linkStyle} onClick={() => handleLinkClick('/logout')}>
             <ListItemButton
               sx={{
-                backgroundColor: '#f5f5f5',
+                backgroundColor: selectedLink === '/logout' ? '#B4CD93' : '#f5f5f5',
                 '&:hover': {
                   backgroundColor: '#edf5e1',
                   cursor: 'pointer',
                 },
+                borderRadius: 2,
               }}
             >
               <ListItemIcon>
-                <LogoutRoundedIcon sx={{ fontSize: 30 }} />
+                <LogoutRoundedIcon
+                  sx={{ fontSize: 30, color: selectedLink === '/logout' ? '#A12C2C' : '#8C2727' }}
+                />
               </ListItemIcon>
-              <ListItemText primary="Logout" primaryTypographyProps={{ sx: { fontSize: 25 } }} />
+              <ListItemText
+                primary="Logout"
+                primaryTypographyProps={{
+                  sx: {
+                    fontSize: 22,
+                    fontWeight: selectedLink === '/logout' ? 'bold' : 'normal',
+                    color: selectedLink === '/logout' ? '#A12C2C' : '#8C2727',
+                  },
+                }}
+              />
             </ListItemButton>
           </NavLink>
         </Box>
@@ -215,20 +317,32 @@ export default function DrawerItems() {
           <NavLink to="/applicantDetails" style={linkStyle}>
             <ListItemButton
               sx={{
-                backgroundColor: '#f5f5f5',
+                backgroundColor: selectedLink === '/applicantDetails' ? '#B4CD93' : '#f5f5f5',
                 '&:hover': {
                   backgroundColor: '#edf5e1',
                   cursor: 'pointer',
                 },
+                borderRadius: 2,
               }}
             >
               <ListItemIcon>
-                <ViewListRoundedIcon sx={{ fontSize: 30 }} />
+                <BadgeRoundedIcon
+                  sx={{
+                    fontSize: 30,
+                    color: selectedLink === '/applicantDetails' ? '#4C4C4C' : '#808080',
+                  }}
+                />
               </ListItemIcon>
               <ListItemText
-                primary="Applicant Details Page"
+                primary="(Applicant Details Page)"
                 sx={{ color: 'red' }}
-                primaryTypographyProps={{ sx: { fontSize: 25 } }}
+                primaryTypographyProps={{
+                  sx: {
+                    fontSize: 22,
+                    fontWeight: selectedLink === '/applicantDetails' ? 'bold' : 'normal',
+                    color: selectedLink === '/applicantDetails' ? '#4C4C4C' : '#808080',
+                  },
+                }}
               />
             </ListItemButton>
           </NavLink>

--- a/src/helper/DrawerItems.tsx
+++ b/src/helper/DrawerItems.tsx
@@ -5,7 +5,7 @@ import GroupsRoundedIcon from '@mui/icons-material/GroupsRounded';
 import MoveToInboxRoundedIcon from '@mui/icons-material/MoveToInboxRounded';
 import BadgeRoundedIcon from '@mui/icons-material/BadgeRounded';
 import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
-import Divider from '@mui/material/Divider';
+import AccountBoxRoundedIcon from '@mui/icons-material/AccountBoxRounded';
 import Collapse from '@mui/material/Collapse';
 import List from '@mui/material/List';
 import ExpandLess from '@mui/icons-material/ExpandLess';
@@ -150,7 +150,7 @@ export default function DrawerItems() {
               onClick={handleClick}
             >
               <ListItemIcon>
-                <PersonAddRoundedIcon
+                <AccountBoxRoundedIcon
                   sx={{
                     fontSize: 30,
                     color: selectedLink === '/applicants' ? '#4C4C4C' : '#808080',
@@ -230,7 +230,7 @@ export default function DrawerItems() {
                   }}
                 >
                   <ListItemIcon>
-                    <FileUploadRoundedIcon
+                    <PersonAddRoundedIcon
                       sx={{
                         fontSize: 30,
                         color: selectedLink === '/applicants/upload' ? '#4C4C4C' : '#808080',
@@ -252,8 +252,7 @@ export default function DrawerItems() {
             </Box>
           </List>
         </Collapse>
-        <Divider sx={{ my: 1 }} />
-        <Box sx={{ marginBottom: '3vh' }}>
+        <Box sx={{ marginBottom: '3vh', marginTop: '20vh' }}>
           <NavLink to="/settings" style={linkStyle} onClick={() => handleLinkClick('/settings')}>
             <ListItemButton
               sx={{
@@ -307,41 +306,6 @@ export default function DrawerItems() {
                     fontSize: 22,
                     fontWeight: selectedLink === '/logout' ? 'bold' : 'normal',
                     color: selectedLink === '/logout' ? '#A12C2C' : '#8C2727',
-                  },
-                }}
-              />
-            </ListItemButton>
-          </NavLink>
-        </Box>
-        <Box sx={{ marginBottom: '3vh' }}>
-          {/* TODO: Request the removal of this link in the drawer at the end of the review process */}
-          <NavLink to="/applicantDetails" style={linkStyle}>
-            <ListItemButton
-              sx={{
-                backgroundColor: selectedLink === '/applicantDetails' ? '#B4CD93' : '#f5f5f5',
-                '&:hover': {
-                  backgroundColor: '#edf5e1',
-                  cursor: 'pointer',
-                },
-                borderRadius: 2,
-              }}
-            >
-              <ListItemIcon>
-                <BadgeRoundedIcon
-                  sx={{
-                    fontSize: 30,
-                    color: selectedLink === '/applicantDetails' ? '#4C4C4C' : '#808080',
-                  }}
-                />
-              </ListItemIcon>
-              <ListItemText
-                primary="(Applicant Details Page)"
-                sx={{ color: 'red' }}
-                primaryTypographyProps={{
-                  sx: {
-                    fontSize: 22,
-                    fontWeight: selectedLink === '/applicantDetails' ? 'bold' : 'normal',
-                    color: selectedLink === '/applicantDetails' ? '#4C4C4C' : '#808080',
                   },
                 }}
               />

--- a/src/helper/DrawerItems.tsx
+++ b/src/helper/DrawerItems.tsx
@@ -1,20 +1,20 @@
 import * as React from 'react';
-import ListItemButton from '@mui/material/ListItemButton';
-import ListItemIcon from '@mui/material/ListItemIcon';
-import ListItemText from '@mui/material/ListItemText';
-import DashboardIcon from '@mui/icons-material/Dashboard';
-import PeopleIcon from '@mui/icons-material/People';
-import BarChartIcon from '@mui/icons-material/BarChart';
-import LayersIcon from '@mui/icons-material/Layers';
-import AssignmentIcon from '@mui/icons-material/Assignment';
+import { ListItemButton, ListItemIcon, ListItemText, Box } from '@mui/material';
+import DashboardRoundedIcon from '@mui/icons-material/DashboardRounded';
+import GroupsRoundedIcon from '@mui/icons-material/GroupsRounded';
+import MoveToInboxRoundedIcon from '@mui/icons-material/MoveToInboxRounded';
+import ViewListRoundedIcon from '@mui/icons-material/ViewListRounded';
+import SettingsRoundedIcon from '@mui/icons-material/SettingsRounded';
 import Divider from '@mui/material/Divider';
-import { NavLink } from 'react-router-dom';
 import Collapse from '@mui/material/Collapse';
 import List from '@mui/material/List';
 import ExpandLess from '@mui/icons-material/ExpandLess';
 import ExpandMore from '@mui/icons-material/ExpandMore';
-import FileUploadIcon from '@mui/icons-material/FileUpload';
-import GridViewIcon from '@mui/icons-material/GridView';
+import FileUploadRoundedIcon from '@mui/icons-material/FileUploadRounded';
+import PersonAddRoundedIcon from '@mui/icons-material/PersonAddRounded';
+import LogoutRoundedIcon from '@mui/icons-material/LogoutRounded';
+import { NavLink } from 'react-router-dom';
+import { useState } from 'react';
 
 const linkStyle = {
   textDecoration: 'none',
@@ -22,86 +22,42 @@ const linkStyle = {
 };
 
 export default function DrawerItems() {
-  const [open, setOpen] = React.useState(true);
+  const [open, setOpen] = useState(true);
+  const [selectedLink, setSelectedLink] = useState<string>(''); // State to track selected link
 
   const handleClick = () => {
     setOpen(!open);
   };
 
+  const handleLinkClick = (link: string) => {
+    setSelectedLink(link); // Update selected link on click
+  };
+
   return (
     <React.Fragment>
-      <NavLink to="/" style={linkStyle}>
-        <ListItemButton
-          sx={{
-            backgroundColor: '#f5f5f5',
-            '&:hover': {
-              backgroundColor: '#edf5e1',
-              cursor: 'pointer',
-            },
-          }}
-        >
-          <ListItemIcon>
-            <DashboardIcon />
-          </ListItemIcon>
-          <ListItemText primary="Dashboard" />
-        </ListItemButton>
-      </NavLink>
-      <NavLink to="/vacancies" style={linkStyle}>
-        <ListItemButton
-          sx={{
-            backgroundColor: '#f5f5f5',
-            '&:hover': {
-              backgroundColor: '#edf5e1',
-              cursor: 'pointer',
-            },
-          }}
-        >
-          <ListItemIcon>
-            <LayersIcon />
-          </ListItemIcon>
-          <ListItemText primary="Vacancies" />
-        </ListItemButton>
-      </NavLink>
-      <NavLink to="/inquiries" style={linkStyle}>
-        <ListItemButton
-          sx={{
-            backgroundColor: '#f5f5f5',
-            '&:hover': {
-              backgroundColor: '#edf5e1',
-              cursor: 'pointer',
-            },
-          }}
-        >
-          <ListItemIcon>
-            <BarChartIcon />
-          </ListItemIcon>
-          <ListItemText primary="Inquiries" />
-        </ListItemButton>
-      </NavLink>
-      <NavLink to="/applicants" style={linkStyle}>
-        <ListItemButton
-          sx={{
-            backgroundColor: '#f5f5f5',
-            '&:hover': {
-              backgroundColor: '#edf5e1',
-              cursor: 'pointer',
-            },
-          }}
-          onClick={handleClick}
-        >
-          <ListItemIcon>
-            <PeopleIcon />
-          </ListItemIcon>
-          <ListItemText primary="Applicants" />
-          {open ? <ExpandLess /> : <ExpandMore />}
-        </ListItemButton>
-      </NavLink>
-      <Collapse in={open} timeout="auto" unmountOnExit>
-        <List component="div" disablePadding>
-          <NavLink to="/applicants/overview" style={linkStyle}>
+      <Box sx={{ marginTop: '5vh', marginLeft: '1vh', marginRight: '1vh' }}>
+        <Box sx={{ marginBottom: '3vh', borderRadius: 5 }}>
+          <NavLink to="/" style={linkStyle} onClick={() => handleLinkClick('/')}>
             <ListItemButton
               sx={{
-                pl: 4,
+                backgroundColor: selectedLink === '/' ? '#B4CD93' : '#f5f5f5',
+                '&:hover': {
+                  backgroundColor: '#edf5e1',
+                  cursor: 'pointer',
+                },
+              }}
+            >
+              <ListItemIcon>
+                <DashboardRoundedIcon sx={{ fontSize: 30 }} />
+              </ListItemIcon>
+              <ListItemText primary="Dashboard" primaryTypographyProps={{ sx: { fontSize: 25 } }} />
+            </ListItemButton>
+          </NavLink>
+        </Box>
+        <Box sx={{ marginBottom: '3vh' }}>
+          <NavLink to="/vacancies" style={linkStyle} onClick={() => handleLinkClick('/vacancies')}>
+            <ListItemButton
+              sx={{
                 backgroundColor: '#f5f5f5',
                 '&:hover': {
                   backgroundColor: '#edf5e1',
@@ -110,15 +66,16 @@ export default function DrawerItems() {
               }}
             >
               <ListItemIcon>
-                <GridViewIcon />
+                <ViewListRoundedIcon sx={{ fontSize: 30 }} />
               </ListItemIcon>
-              <ListItemText primary="Overview" />
+              <ListItemText primary="Vacancies" primaryTypographyProps={{ sx: { fontSize: 25 } }} />
             </ListItemButton>
           </NavLink>
-          <NavLink to="/applicants/upload" style={linkStyle}>
+        </Box>
+        <Box sx={{ marginBottom: '3vh' }}>
+          <NavLink to="/inquiries" style={linkStyle} onClick={() => handleLinkClick('/inquiries')}>
             <ListItemButton
               sx={{
-                pl: 4,
                 backgroundColor: '#f5f5f5',
                 '&:hover': {
                   backgroundColor: '#edf5e1',
@@ -127,47 +84,156 @@ export default function DrawerItems() {
               }}
             >
               <ListItemIcon>
-                <FileUploadIcon />
+                <MoveToInboxRoundedIcon sx={{ fontSize: 30 }} />
               </ListItemIcon>
-              <ListItemText primary="Upload" />
+              <ListItemText primary="Inquiries" primaryTypographyProps={{ sx: { fontSize: 25 } }} />
             </ListItemButton>
           </NavLink>
-        </List>
-      </Collapse>
-      <Divider sx={{ my: 1 }} />
-      <NavLink to="/settings" style={linkStyle}>
-        <ListItemButton
-          sx={{
-            backgroundColor: '#f5f5f5',
-            '&:hover': {
-              backgroundColor: '#edf5e1',
-              cursor: 'pointer',
-            },
-          }}
-        >
-          <ListItemIcon>
-            <AssignmentIcon />
-          </ListItemIcon>
-          <ListItemText primary="Settings" />
-        </ListItemButton>
-      </NavLink>
-      {/* TODO: Request the removal of this link in the drawer at the end of the review process */}
-      <NavLink to="/applicantDetails" style={linkStyle}>
-        <ListItemButton
-          sx={{
-            backgroundColor: '#f5f5f5',
-            '&:hover': {
-              backgroundColor: '#edf5e1',
-              cursor: 'pointer',
-            },
-          }}
-        >
-          <ListItemIcon>
-            <LayersIcon />
-          </ListItemIcon>
-          <ListItemText primary="Applicant Details Page" sx={{ color: 'red' }} />
-        </ListItemButton>
-      </NavLink>
+        </Box>
+        <Box sx={{ marginBottom: '3vh' }}>
+          <NavLink
+            to="/applicants"
+            style={linkStyle}
+            onClick={() => handleLinkClick('/applicants')}
+          >
+            <ListItemButton
+              sx={{
+                backgroundColor: '#f5f5f5',
+                '&:hover': {
+                  backgroundColor: '#edf5e1',
+                  cursor: 'pointer',
+                },
+              }}
+              onClick={handleClick}
+            >
+              <ListItemIcon>
+                <PersonAddRoundedIcon sx={{ fontSize: 30 }} />
+              </ListItemIcon>
+              <ListItemText
+                primary="Applicants"
+                primaryTypographyProps={{ sx: { fontSize: 25 } }}
+              />
+              {open ? <ExpandLess /> : <ExpandMore />}
+            </ListItemButton>
+          </NavLink>
+        </Box>
+        <Collapse in={open} timeout="auto" unmountOnExit>
+          <List component="div" disablePadding>
+            <Box sx={{ marginBottom: '3vh' }}>
+              <NavLink
+                to="/applicants/overview"
+                style={linkStyle}
+                onClick={() => handleLinkClick('/applicants/overview')}
+              >
+                <ListItemButton
+                  sx={{
+                    pl: 4,
+                    backgroundColor: '#f5f5f5',
+                    '&:hover': {
+                      backgroundColor: '#edf5e1',
+                      cursor: 'pointer',
+                    },
+                  }}
+                >
+                  <ListItemIcon>
+                    <GroupsRoundedIcon sx={{ fontSize: 30 }} />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Overview"
+                    primaryTypographyProps={{ sx: { fontSize: 20 } }}
+                  />
+                </ListItemButton>
+              </NavLink>
+            </Box>
+            <Box sx={{ marginBottom: '3vh' }}>
+              <NavLink
+                to="/applicants/upload"
+                style={linkStyle}
+                onClick={() => handleLinkClick('/applicants/upload')}
+              >
+                <ListItemButton
+                  sx={{
+                    pl: 4,
+                    backgroundColor: '#f5f5f5',
+                    '&:hover': {
+                      backgroundColor: '#edf5e1',
+                      cursor: 'pointer',
+                    },
+                  }}
+                >
+                  <ListItemIcon>
+                    <FileUploadRoundedIcon sx={{ fontSize: 30 }} />
+                  </ListItemIcon>
+                  <ListItemText
+                    primary="Upload"
+                    primaryTypographyProps={{ sx: { fontSize: 20 } }}
+                  />
+                </ListItemButton>
+              </NavLink>
+            </Box>
+          </List>
+        </Collapse>
+        <Divider sx={{ my: 1 }} />
+        <Box sx={{ marginBottom: '3vh' }}>
+          <NavLink to="/settings" style={linkStyle} onClick={() => handleLinkClick('/settings')}>
+            <ListItemButton
+              sx={{
+                backgroundColor: '#f5f5f5',
+                '&:hover': {
+                  backgroundColor: '#edf5e1',
+                  cursor: 'pointer',
+                },
+              }}
+            >
+              <ListItemIcon>
+                <SettingsRoundedIcon sx={{ fontSize: 30 }} />
+              </ListItemIcon>
+              <ListItemText primary="Settings" primaryTypographyProps={{ sx: { fontSize: 25 } }} />
+            </ListItemButton>
+          </NavLink>
+        </Box>
+        <Box sx={{ marginBottom: '3vh' }}>
+          <NavLink to="/logout" style={linkStyle} onClick={() => handleLinkClick('/logout')}>
+            <ListItemButton
+              sx={{
+                backgroundColor: '#f5f5f5',
+                '&:hover': {
+                  backgroundColor: '#edf5e1',
+                  cursor: 'pointer',
+                },
+              }}
+            >
+              <ListItemIcon>
+                <LogoutRoundedIcon sx={{ fontSize: 30 }} />
+              </ListItemIcon>
+              <ListItemText primary="Logout" primaryTypographyProps={{ sx: { fontSize: 25 } }} />
+            </ListItemButton>
+          </NavLink>
+        </Box>
+        <Box sx={{ marginBottom: '3vh' }}>
+          {/* TODO: Request the removal of this link in the drawer at the end of the review process */}
+          <NavLink to="/applicantDetails" style={linkStyle}>
+            <ListItemButton
+              sx={{
+                backgroundColor: '#f5f5f5',
+                '&:hover': {
+                  backgroundColor: '#edf5e1',
+                  cursor: 'pointer',
+                },
+              }}
+            >
+              <ListItemIcon>
+                <ViewListRoundedIcon sx={{ fontSize: 30 }} />
+              </ListItemIcon>
+              <ListItemText
+                primary="Applicant Details Page"
+                sx={{ color: 'red' }}
+                primaryTypographyProps={{ sx: { fontSize: 25 } }}
+              />
+            </ListItemButton>
+          </NavLink>
+        </Box>
+      </Box>
     </React.Fragment>
   );
 }

--- a/src/helper/DrawerItems.tsx
+++ b/src/helper/DrawerItems.tsx
@@ -18,6 +18,7 @@ import { useState } from 'react';
 
 const linkStyle = {
   textDecoration: 'none',
+  color: '#808080',
 };
 
 export default function DrawerItems() {

--- a/src/pages/VacancyPage.tsx
+++ b/src/pages/VacancyPage.tsx
@@ -88,6 +88,7 @@ export default function VacancyPage() {
           color="secondary"
           page={currentPage}
           onChange={handlePageChange}
+          sx={{ marginTop: '2vh', marginBottom: '2vh' }}
         />
       </Box>
     </Box>


### PR DESCRIPTION
- made drawer wider
- increased font size, font weight (when selected) and icon size
- added background color based on the selected route
- adjusted text and icon colors (selected and not selected) to match the mockup
- removed divider between 'Upload' and 'Settings' and added space instead
- switched out icons to more fitting ones
- 'Logout' is now red 🔥 

Sorry for this huge screenshot 😅 
![image](https://github.com/HdM-LLM/frontend/assets/95630400/691689ce-41b1-4d22-8a90-9e39afbc22d8)
